### PR TITLE
Supress warning on chrome

### DIFF
--- a/boombox.js
+++ b/boombox.js
@@ -242,7 +242,7 @@
              * @name AudioContext
              * @type {AudioContext}
              */
-            this.AudioContext = w.webkitAudioContext || w.AudioContext;
+            this.AudioContext = w.AudioContext || w.webkitAudioContext;
 
             /**
              * Environmental support information


### PR DESCRIPTION
Hi.
Recent chrome warn this message in console log.

~~~
'webkitAudioContext' is deprecated. Please use 'AudioContext' instead.
~~~

This change suppress this message.